### PR TITLE
Potential download package fix

### DIFF
--- a/express/src/document/document.repo.ts
+++ b/express/src/document/document.repo.ts
@@ -48,16 +48,17 @@ export class DocumentRepo {
   };
 
   deleteDocument = async (documentId: string) => {
-    await this
-      .sql`DELETE FROM document WHERE id = ${documentId}`;
-    logger.info(
-      `Document with ID ${documentId} was deleted`
-    );
+    await this.sql`DELETE FROM document WHERE id = ${documentId}`;
+    logger.info(`Document with ID ${documentId} was deleted`);
     return { documentId };
   };
 
   getDocumentUML = async (roomId: string, documentId: number) => {
-    const doc = await this.yjsHelpers.getDoc(roomId + documentId, this.redis);
+    const doc = await this.yjsHelpers.getDoc(
+      roomId + documentId,
+      this.redis,
+      this.sql
+    );
     return doc.getText("monaco").toString();
   };
 }

--- a/express/src/yjs/yjs.helpers.ts
+++ b/express/src/yjs/yjs.helpers.ts
@@ -1,11 +1,27 @@
 import * as Y from "yjs";
 import * as decoding from "lib0/decoding";
+import * as awarenessProtocol from "y-protocols/awareness";
 import * as array from "lib0/array";
 import * as map from "lib0/map";
 import { RedisClientType } from "redis";
 import * as encoding from "lib0/encoding";
+import { Sql } from "postgres";
 
-const getDoc = async (room: string, redis: RedisClientType) => {
+const retrieveDoc = async (room: string, docname: string, sql: Sql) => {
+  /**
+   * @type {Array<{ room: string, doc: string, r: number, update: Buffer }>}
+   */
+  const rows =
+    await sql`SELECT update,r from yredis_docs_v1 WHERE room = ${room} AND doc = ${docname}`;
+  if (rows.length === 0) {
+    return null;
+  }
+  const doc = Y.mergeUpdatesV2(rows.map((row: any) => row.update));
+  const references = rows.map((row: any) => row.r);
+  return { doc, references };
+};
+
+const getDoc = async (room: string, redis: RedisClientType, sql: Sql) => {
   const docid = "index";
   const ms = extractMessagesFromStreamReply(
     await redis.xRead(redis.commandOptions({ returnBuffers: true }), {
@@ -16,16 +32,34 @@ const getDoc = async (room: string, redis: RedisClientType) => {
   );
 
   const docMessages = ms.get(room)?.get(docid) || null;
+  const docstate = await retrieveDoc(room, docid, sql);
   const ydoc = new Y.Doc();
+  const awareness = new awarenessProtocol.Awareness(ydoc);
+  awareness.setLocalState(null); // we don't want to propagate awareness state
+  if (docstate) {
+    Y.applyUpdateV2(ydoc, docstate.doc);
+  }
 
   ydoc.transact(() => {
     docMessages?.messages.forEach((m: any) => {
       const decoder = decoding.createDecoder(m);
-      if (decoding.readVarUint(decoder) === 0) {
-        // sync message
-        if (decoding.readVarUint(decoder) === 2) {
-          // update message
-          Y.applyUpdate(ydoc, decoding.readVarUint8Array(decoder));
+      switch (decoding.readVarUint(decoder)) {
+        case 0: {
+          // sync message
+          if (decoding.readVarUint(decoder) === 2) {
+            // update message
+            Y.applyUpdate(ydoc, decoding.readVarUint8Array(decoder));
+          }
+          break;
+        }
+        case 1: {
+          // awareness message
+          awarenessProtocol.applyAwarenessUpdate(
+            awareness,
+            decoding.readVarUint8Array(decoder),
+            null
+          );
+          break;
         }
       }
     });


### PR DESCRIPTION
### Intro:

This is a potential fix for the download package issue. It adds a database query to get the initial `YDoc` state before going to redis. This is closer to [what the native y-redis implementation does](https://github.com/nnourr/plant-together/blob/41011822d0c30be23527ea5526f118410d8f9d25/y-redis/src/api.js#L227). 

I say potential fix because I haven't been able to replicate the issue locally, **but** I have tested to make sure that it still works. I can guarantee this won't be a regression

![image](https://github.com/user-attachments/assets/9543cddb-edcd-482d-b012-100035817d07)


### Document Repository Changes:
* [`express/src/document/document.repo.ts`](diffhunk://#diff-e1aa0e11822e684d8dd8cf93b2421f9075027d90813170ad50c1d25147ec56adL51-R61): updated the `getDocumentUML` method to include the `sql` parameter when calling `getDoc`.

### Yjs Helpers Updates:
* [`express/src/yjs/yjs.helpers.ts`](diffhunk://#diff-a15da8d4772299d7e83a91b7965cf39ca1abbf1dfbed66d525f6947cf1f609d7R3-R24): Added imports for `awarenessProtocol` and `Sql` to support awareness updates and SQL queries.
* [`express/src/yjs/yjs.helpers.ts`](diffhunk://#diff-a15da8d4772299d7e83a91b7965cf39ca1abbf1dfbed66d525f6947cf1f609d7R3-R24): Introduced the `retrieveDoc` function to fetch document updates from the database.
* [`express/src/yjs/yjs.helpers.ts`](diffhunk://#diff-a15da8d4772299d7e83a91b7965cf39ca1abbf1dfbed66d525f6947cf1f609d7R35-R63): Updated the `getDoc` function to utilize the `retrieveDoc` function and handle awareness updates.