### PR TITLE
Guest Login on Navigate to Landing Page

### DIFF
--- a/react/src/pages/landing.page.tsx
+++ b/react/src/pages/landing.page.tsx
@@ -66,7 +66,7 @@ export const Landing: React.FC = () => {
     roomName,
     navigate,
     isPrivate,
-    userContext?.context?.userId,
+    userContext,
     plantService,
   ])
 


### PR DESCRIPTION
# Guest Login on Navigate to Landing Page

## Bug 

When navigating to Plant Together's landing page, we expect to be able to enter join a public room, even if no user session is active on other tabs. To join a public room a user or guest token is need for authorization. 

## Reason 

The behavior to achieve token retreival on load is already in place using the [`UserContextProvider`](https://github.com/nnourr/plant-together/blob/main/react/src/components/user.context.tsx) component wrapping our application. However, the logic of navigating to a room uses the initial context value, which is empty if no prior token was located in local storage, and ignores any further updates to the value like when fetching a new token. 

This issue stems from the initialization of our navigation to `collabRoom` logic, specifically the dependency array of the useCallback in the landing page. The dependency array was using the `userId` property within the context instead of the actual context object. Since that field is a string and not a React context, it doesn't trigger a re-render that hits the callback initialization and cause the userId value to be re-evaluated. 

## Fix

By changing the dependency array to watch the provider, it guarantees the update of the context will re-render and re-initialize the callback. When navigating to a room, the callback will use the initialized token instead of undefined.

## Regressions

This doesn't affect the flow when the session already exists in local storage and reuses the existing user token, instead of overwriting it.

## Tests

- Cleared local storage
- Navigated to landing page
- Entered a public room name
- Submitted and observed successful navigation to room